### PR TITLE
Make PSH Route ID configurable

### DIFF
--- a/platformsh-env.php
+++ b/platformsh-env.php
@@ -38,7 +38,7 @@ function mapPlatformShEnvironment() : void
     }
 
     // Set the URL based on the route.  This is a required route ID.
-    setEnvVar('APP_URL', $config->getRoute('shopware')['url']);
+    setEnvVar('APP_URL', $config->getRoute(getenv('PSH_ROUTE_ID') ?: 'shopware')['url']);
 
     mapPlatformShOpenSearch('elasticsearch', $config);
     mapPlatformShOpenSearch('opensearch', $config);


### PR DESCRIPTION
This change is necessary to allow multiple Shopware projects to be hosted within 1 PaaS setup.