### PR TITLE
Bugfix: Multiple shopware routes

### DIFF
--- a/platformsh-env.php
+++ b/platformsh-env.php
@@ -37,8 +37,7 @@ function mapPlatformShEnvironment() : void
         return;
     }
 
-    // Set the URL based on the route.  This is a required route ID.
-    setEnvVar('APP_URL', $config->getRoute(getenv('PSH_ROUTE_ID') ?: 'shopware')['url']);
+    mapPlatformShAppUrl($config);
 
     mapPlatformShOpenSearch('elasticsearch', $config);
     mapPlatformShOpenSearch('opensearch', $config);
@@ -101,6 +100,19 @@ function setEnvVar(string $name, $value) : void
         }
         $_SERVER[$name] = $value;
     }
+}
+
+function mapPlatformShAppUrl(Config $config): void
+{
+    $routeId = getenv('PSH_ROUTE_ID') ?: 'shopware';
+    $route   = $config->getPrimaryRoute();
+
+    if ( ! $route) {
+        $route = $config->getRoute($routeId);
+    }
+
+    // Set the URL based on the route.  This is a required route ID.
+    setEnvVar('APP_URL', $route['url']);
 }
 
 function mapPlatformShOpenSearch(string $relationshipName, Config $config): void

--- a/tests/PaasBridgeShopwareClusterTest.php
+++ b/tests/PaasBridgeShopwareClusterTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Shopware\Paas\Tests;
+
+use function Platformsh\ShopwareBridge\mapPlatformShEnvironment;
+
+class PaasBridgeShopwareClusterTest extends PaasBridgeShopwareTest
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        // Switched primary URL from first to second position routes. This is a real-world condition we're facing with PSH.
+        //  Yes, both routes also have the type "shopware" assigned.
+        \putenv('PLATFORM_ROUTES='.\base64_encode('{"https://test.tst.site/": {"primary": false, "id": "shopware", "production_url": null, "attributes": {}, "type": "upstream", "upstream": "app", "original_url": "https://{default}/"}, "https://prod.site/": {"original_url": "http://{default}/", "id": "shopware", "primary": true, "production_url": null, "attributes": {}, "type": "upstream", "production_url": null}}'));
+    }
+
+    public function testAppUrlSet(): void
+    {
+        mapPlatformShEnvironment();
+
+        $this->assertEquals('https://prod.site/', getenv('APP_URL'));
+    }
+}

--- a/tests/PaasBridgeShopwareClusterTest.php
+++ b/tests/PaasBridgeShopwareClusterTest.php
@@ -9,8 +9,8 @@ class PaasBridgeShopwareClusterTest extends PaasBridgeShopwareTest
     public function setUp(): void
     {
         parent::setUp();
-        // Switched primary URL from first to second position routes. This is a real-world condition we're facing with PSH.
-        //  Yes, both routes also have the type "shopware" assigned.
+
+        // The non-primary URL goes first, then the actual production-domain, both routes also have the type "shopware" assigned. This is a real-world condition we're facing with PSH.
         \putenv('PLATFORM_ROUTES='.\base64_encode('{"https://test.tst.site/": {"primary": false, "id": "shopware", "production_url": null, "attributes": {}, "type": "upstream", "upstream": "app", "original_url": "https://{default}/"}, "https://prod.site/": {"original_url": "http://{default}/", "id": "shopware", "primary": true, "production_url": null, "attributes": {}, "type": "upstream", "production_url": null}}'));
     }
 


### PR DESCRIPTION
Currently, when there are multiple routes of type `"shopware"` in the `PLATFORM_ROUTES`, with the first not being the primary (production domain), this will lead to issues with the `AppUrlChecker` downstream.

That will cause the administration's `APP_URL` warning message to always display, even though the actually correct URL is available and reachable.

As a side-effect, without this change, we always get the wrong URL for `APP_URL` in the Nginx/PHP-FPM process, which makes it unreliable for certain processed. Hence, I'm PRing this, in the hopes of resolving this edge-case.

According to tests, the change does not affect the existing functionality in a negative fashion.