### PR TITLE
Remove the trailing slash in APP_URL

### DIFF
--- a/platformsh-env.php
+++ b/platformsh-env.php
@@ -113,7 +113,8 @@ function mapPlatformShAppUrl(Config $config): void
     }
 
     // Set the URL based on the route.  This is a required route ID.
-    setEnvVar('APP_URL', $route['url']);
+    $appUrl = rtrim($route['url'], '/');
+    setEnvVar('APP_URL', $appUrl);
 }
 
 function mapPlatformShOpenSearch(string $relationshipName, Config $config): void

--- a/tests/PaasBridgeShopwareClusterTest.php
+++ b/tests/PaasBridgeShopwareClusterTest.php
@@ -18,6 +18,6 @@ class PaasBridgeShopwareClusterTest extends PaasBridgeShopwareTest
     {
         mapPlatformShEnvironment();
 
-        $this->assertEquals('https://prod.site/', getenv('APP_URL'));
+        $this->assertEquals('https://prod.site', getenv('APP_URL'));
     }
 }

--- a/tests/PaasBridgeShopwareTest.php
+++ b/tests/PaasBridgeShopwareTest.php
@@ -20,6 +20,6 @@ class PaasBridgeShopwareTest extends TestCase
     {
         mapPlatformShEnvironment();
 
-        $this->assertEquals('https://test.tst.site/', getenv('APP_URL'));
+        $this->assertEquals('https://test.tst.site', getenv('APP_URL'));
     }
 }


### PR DESCRIPTION
Update `APP_URL` to remove trailing slash in `platformsh-env.php` and related tests.

* **platformsh-env.php**
  - Modify the `mapPlatformShAppUrl` function to remove the trailing slash from the `APP_URL` before setting it.

* **tests/PaasBridgeShopwareTest.php**
  - Update the `testAppUrlSet` function to expect the `APP_URL` without a trailing slash.

* **tests/PaasBridgeShopwareClusterTest.php**
  - Update the `testAppUrlSet` function to expect the `APP_URL` without a trailing slash.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shopware/paas-meta/pull/5?shareId=db02c988-05ed-482c-bb7a-0ed5d18f7b7d).