### PR TITLE
fix: Don't override explicitly set app url

### DIFF
--- a/platformsh-env.php
+++ b/platformsh-env.php
@@ -105,6 +105,11 @@ function setEnvVar(string $name, $value) : void
 
 function mapPlatformShAppUrl(Config $config): void
 {
+    if (!empty(getenv('APP_URL')) {
+        // don't override manual configured APP_URL
+        return;
+    }
+
     $routeId = getenv('PSH_ROUTE_ID') ?: 'shopware';
     $route   = $config->getPrimaryRoute();
 

--- a/platformsh-env.php
+++ b/platformsh-env.php
@@ -105,8 +105,8 @@ function setEnvVar(string $name, $value) : void
 
 function mapPlatformShAppUrl(Config $config): void
 {
-    if (!empty(getenv('APP_URL')) {
-        // don't override manual configured APP_URL
+    if (!empty(getenv('APP_URL'))) {
+        // don't override manually configured APP_URL
         return;
     }
 


### PR DESCRIPTION
When you explicitly set the app url env var it will be overridden here, leading to issues where the env in bash is different then on PHP because we override it here, which leads to misconfiguration and support cases