### PR TITLE
feat: Set MESSENGER_TRANSPORT_DSN_PREFIX env variable

### DIFF
--- a/platformsh-env.php
+++ b/platformsh-env.php
@@ -44,6 +44,7 @@ function mapPlatformShEnvironment() : void
 
     $config->registerFormatter('doctrine', __NAMESPACE__ . '\doctrineFormatter');
     $config->registerFormatter('rabbitmq', __NAMESPACE__ . '\rabbitMqFormatter');
+    $config->registerFormatter('rabbitmqPrefix', __NAMESPACE__ . '\rabbitMqFormatterPrefix');
 
     // Set the application secret if it's not already set.
     // We force re-setting the APP_SECRET to ensure it's set in all of PHP's various
@@ -162,13 +163,28 @@ function mapPlatformShMailer(Config $config)
 /**
  * Formatter for the Symfony RabbitMQ Messenger format.
  *
- * The %2f default vhost is not a formatting code, but a URL-encoded
- * forward slash (/), which is the default vhost name in RabbitMQ.
- * It's a weird default name, but it's what RabbitMQ uses.
+ * Returns a full URL including the trailing exchange name "/messages"
  */
 function rabbitMqFormatter(array $credentials): string
 {
-    return sprintf('%s://%s:%s@%s:%d/%s/messages',
+    return sprintf('%s/messages',
+        rabbitMqFormatterPrefix($credentials)
+    );
+}
+
+/**
+ * Formatter for the Symfony RabbitMQ Messenger format.
+ *
+ * The %2f default vhost is not a formatting code, but a URL-encoded
+ * forward slash (/), which is the default vhost name in RabbitMQ.
+ * It's a weird default name, but it's what RabbitMQ uses.
+ *
+ * Formats the URL without the trailing exchange name. The value can
+ * be used as a prefix for different transports.
+ */
+function rabbitMqFormatterPrefix(array $credentials): string
+{
+    return sprintf('%s://%s:%s@%s:%d/%s',
         $credentials['scheme'],
         $credentials['username'],
         $credentials['password'],
@@ -297,6 +313,7 @@ function mapPlatformShRabbitMq(string $relationshipName, Config $config) : void
     }
 
     setEnvVar('MESSENGER_TRANSPORT_DSN', $config->formattedCredentials($relationshipName, 'rabbitmq'));
+    setEnvVar('MESSENGER_TRANSPORT_DSN_PREFIX', $config->formattedCredentials($relationshipName, 'rabbitmqPrefix'));
 }
 
 /**

--- a/platformsh-env.php
+++ b/platformsh-env.php
@@ -167,7 +167,7 @@ function mapPlatformShMailer(Config $config)
  */
 function rabbitMqFormatter(array $credentials): string
 {
-    return sprintf('%s/messages',
+    return sprintf('%smessages',
         rabbitMqFormatterPrefix($credentials)
     );
 }
@@ -184,7 +184,7 @@ function rabbitMqFormatter(array $credentials): string
  */
 function rabbitMqFormatterPrefix(array $credentials): string
 {
-    return sprintf('%s://%s:%s@%s:%d/%s',
+    return sprintf('%s://%s:%s@%s:%d/%s/',
         $credentials['scheme'],
         $credentials['username'],
         $credentials['password'],

--- a/tests/PaasBridgeRabbitMqTest.php
+++ b/tests/PaasBridgeRabbitMqTest.php
@@ -40,6 +40,7 @@ class PaasBridgeRabbitMqTest extends TestCase
         mapPlatformShEnvironment();
 
         $this->assertArrayNotHasKey('MESSENGER_TRANSPORT_DSN', $_SERVER);
+        $this->assertArrayNotHasKey('MESSENGER_TRANSPORT_DSN_PREFIX', $_SERVER);
     }
 
     public function testNoRabbitMqRelationship(): void
@@ -57,6 +58,7 @@ class PaasBridgeRabbitMqTest extends TestCase
         mapPlatformShEnvironment();
 
         $this->assertArrayNotHasKey('MESSENGER_TRANSPORT_DSN', $_SERVER);
+        $this->assertArrayNotHasKey('MESSENGER_TRANSPORT_DSN_PREFIX', $_SERVER);
     }
 
     public function testRelationshipSet(): void
@@ -70,5 +72,6 @@ class PaasBridgeRabbitMqTest extends TestCase
         mapPlatformShEnvironment();
 
         $this->assertEquals('amqp://guest:guest@rabbitmq.internal:5672/%2f/messages', $_SERVER['MESSENGER_TRANSPORT_DSN']);
+        $this->assertEquals('amqp://guest:guest@rabbitmq.internal:5672/%2f', $_SERVER['MESSENGER_TRANSPORT_DSN_PREFIX']);
     }
 }

--- a/tests/PaasBridgeRabbitMqTest.php
+++ b/tests/PaasBridgeRabbitMqTest.php
@@ -72,6 +72,6 @@ class PaasBridgeRabbitMqTest extends TestCase
         mapPlatformShEnvironment();
 
         $this->assertEquals('amqp://guest:guest@rabbitmq.internal:5672/%2f/messages', $_SERVER['MESSENGER_TRANSPORT_DSN']);
-        $this->assertEquals('amqp://guest:guest@rabbitmq.internal:5672/%2f', $_SERVER['MESSENGER_TRANSPORT_DSN_PREFIX']);
+        $this->assertEquals('amqp://guest:guest@rabbitmq.internal:5672/%2f/', $_SERVER['MESSENGER_TRANSPORT_DSN_PREFIX']);
     }
 }


### PR DESCRIPTION
This allows the configuration of different transports with dedicated exchange names:

```yaml
framework:
  messenger:
    transports:
      low_priority:
        dsn: '%env(MESSENGER_TRANSPORT_DSN_PREFIX)%/low_priority'
```

Resolves: #14 